### PR TITLE
Update 'Partially meets requirement' status label

### DIFF
--- a/YukonVaccinationVerifier/YukonVaccinationVerifier/Localization/en.lproj/Localizable.strings
+++ b/YukonVaccinationVerifier/YukonVaccinationVerifier/Localization/en.lproj/Localizable.strings
@@ -12,7 +12,7 @@
 "View.Label.Camera...UseThisApp" = "Camera access is necessary to use this app.";
 "View.Label.FullyVaccinated" = "Fully vaccinated";
 "View.Label.OfficialGovernmentOfYukonResult" = "Official Government of Yukon result";
-"View.Label.PartiallyVaccinated" = "Partially vaccinated";
+"View.Label.PartiallyMeetsRequirement" = "Partially meets requirement";
 "View.Label.NoRecordsFound" = "No Records Found";
 "View.Label.PleaseUpdate" = "Please Update";
 "View.Label.ANewVersion...AppStore" = "A new version of this app is available on the app store";

--- a/YukonVaccinationVerifier/YukonVaccinationVerifier/Localization/fr-CA.lproj/Localizable.strings
+++ b/YukonVaccinationVerifier/YukonVaccinationVerifier/Localization/fr-CA.lproj/Localizable.strings
@@ -12,7 +12,7 @@
 "View.Label.Camera...UseThisApp" = "Vous devez autoriser l’accès à la caméra pour pouvoir utiliser l’application.";
 "View.Label.FullyVaccinated" = "Pleinement vacciné";
 "View.Label.OfficialGovernmentOfYukonResult" = "Résultat officiel du gouvernement du Yukon";
-"View.Label.PartiallyVaccinated" = "Partiellement vacciné";
+"View.Label.PartiallyMeetsRequirement" = "Répond partiellement aux exigences";
 "View.Label.NoRecordsFound" = "Aucun dossier trouvé";
 "View.Label.PleaseUpdate" = "Veuillez mettre à jour.";
 "View.Label.ANewVersion...AppStore" = "Nouvelle version téléchargeable à partir du magasin d’applications";

--- a/YukonVaccinationVerifier/YukonVaccinationVerifier/Shared/Extensions/String+Ext.swift
+++ b/YukonVaccinationVerifier/YukonVaccinationVerifier/Shared/Extensions/String+Ext.swift
@@ -20,8 +20,7 @@ internal extension String {
     }
     static var officialGovernmentOfYukonResult: String { LanguageService.dynamicLocalizedString("View.Label.OfficialGovernmentOfYukonResult")
     }
-    static var partiallyVaccinated: String { LanguageService.dynamicLocalizedString("View.Label.PartiallyVaccinated")
-    }
+    static var partiallyVaccinated: String { LanguageService.dynamicLocalizedString("View.Label.PartiallyMeetsRequirement") }
     static var noRecordsFound: String { LanguageService.dynamicLocalizedString("View.Label.NoRecordsFound")
     }
     static var pleaseUpdate: String { LanguageService.dynamicLocalizedString("View.Label.PleaseUpdate")


### PR DESCRIPTION
The client will be expanding the QR codes issued by the Government of Yukon, and the existing status screen wording is too narrow. The client would like to update the language on the ‘Partially vaccinated’ screen to read 'Partially meets requirement’. This update is also required in the French version of the app.
