### PR TITLE
Update 'Partially meets requirement' status label

### DIFF
--- a/YukonVaccinationVerifier/YukonVaccinationVerifier/Constants/Constants.swift
+++ b/YukonVaccinationVerifier/YukonVaccinationVerifier/Constants/Constants.swift
@@ -198,9 +198,9 @@ struct Constants {
                 static var cardTitle: String { .fullyVaccinated }
                 static var cardSubtitle: String { .officialGovernmentOfYukonResult }
             }
-            struct partiallyVaccinated {
+            struct partiallyMeetsRequirement {
                 static let color = UIColor(hexString: "#F2A900")
-                static var cardTitle: String { .partiallyVaccinated }
+                static var cardTitle: String { .partiallyMeetsRequirement }
                 static var cardSubtitle: String { .officialGovernmentOfYukonResult }
             }
             

--- a/YukonVaccinationVerifier/YukonVaccinationVerifier/Localization/en.lproj/Localizable.strings
+++ b/YukonVaccinationVerifier/YukonVaccinationVerifier/Localization/en.lproj/Localizable.strings
@@ -12,7 +12,7 @@
 "View.Label.Camera...UseThisApp" = "Camera access is necessary to use this app.";
 "View.Label.FullyVaccinated" = "Fully vaccinated";
 "View.Label.OfficialGovernmentOfYukonResult" = "Official Government of Yukon result";
-"View.Label.PartiallyVaccinated" = "Partially vaccinated";
+"View.Label.PartiallyMeetsRequirement" = "Partially meets requirement";
 "View.Label.NoRecordsFound" = "No Records Found";
 "View.Label.PleaseUpdate" = "Please Update";
 "View.Label.ANewVersion...AppStore" = "A new version of this app is available on the app store";

--- a/YukonVaccinationVerifier/YukonVaccinationVerifier/Localization/fr-CA.lproj/Localizable.strings
+++ b/YukonVaccinationVerifier/YukonVaccinationVerifier/Localization/fr-CA.lproj/Localizable.strings
@@ -12,7 +12,7 @@
 "View.Label.Camera...UseThisApp" = "Vous devez autoriser l’accès à la caméra pour pouvoir utiliser l’application.";
 "View.Label.FullyVaccinated" = "Pleinement vacciné";
 "View.Label.OfficialGovernmentOfYukonResult" = "Résultat officiel du gouvernement du Yukon";
-"View.Label.PartiallyVaccinated" = "Partiellement vacciné";
+"View.Label.PartiallyMeetsRequirement" = "Répond partiellement aux exigences";
 "View.Label.NoRecordsFound" = "Aucun dossier trouvé";
 "View.Label.PleaseUpdate" = "Veuillez mettre à jour.";
 "View.Label.ANewVersion...AppStore" = "Nouvelle version téléchargeable à partir du magasin d’applications";

--- a/YukonVaccinationVerifier/YukonVaccinationVerifier/ScanResultViewController.swift
+++ b/YukonVaccinationVerifier/YukonVaccinationVerifier/ScanResultViewController.swift
@@ -165,13 +165,13 @@ internal final class ScanResultViewController: BaseViewController {
     }
     
     private func stylePartiallyVaxinatedCard() {
-        statusContainer.backgroundColor = Constants.UI.Status.partiallyVaccinated.color
+        statusContainer.backgroundColor = Constants.UI.Status.partiallyMeetsRequirement.color
         styleStatusCard(foregroundColor: .black)
         cardIcon.isHidden = true
-        let resultTitle = Constants.UI.Status.partiallyVaccinated.cardTitle
+        let resultTitle = Constants.UI.Status.partiallyMeetsRequirement.cardTitle
         cardTitle.text = resultTitle
         cardTitle.accessibilityLabel = resultTitle
-        cardSubtitle.text = Constants.UI.Status.partiallyVaccinated.cardSubtitle
+        cardSubtitle.text = Constants.UI.Status.partiallyMeetsRequirement.cardSubtitle
         cardTitle.textAlignment = .center
         statusCardContainer.layer.borderWidth = 0
         view.layoutIfNeeded()

--- a/YukonVaccinationVerifier/YukonVaccinationVerifier/Shared/Extensions/String+Ext.swift
+++ b/YukonVaccinationVerifier/YukonVaccinationVerifier/Shared/Extensions/String+Ext.swift
@@ -20,8 +20,7 @@ internal extension String {
     }
     static var officialGovernmentOfYukonResult: String { LanguageService.dynamicLocalizedString("View.Label.OfficialGovernmentOfYukonResult")
     }
-    static var partiallyVaccinated: String { LanguageService.dynamicLocalizedString("View.Label.PartiallyVaccinated")
-    }
+    static var partiallyVaccinated: String { LanguageService.dynamicLocalizedString("View.Label.PartiallyMeetsRequirement") }
     static var noRecordsFound: String { LanguageService.dynamicLocalizedString("View.Label.NoRecordsFound")
     }
     static var pleaseUpdate: String { LanguageService.dynamicLocalizedString("View.Label.PleaseUpdate")

--- a/YukonVaccinationVerifier/YukonVaccinationVerifier/Shared/Extensions/String+Ext.swift
+++ b/YukonVaccinationVerifier/YukonVaccinationVerifier/Shared/Extensions/String+Ext.swift
@@ -20,7 +20,7 @@ internal extension String {
     }
     static var officialGovernmentOfYukonResult: String { LanguageService.dynamicLocalizedString("View.Label.OfficialGovernmentOfYukonResult")
     }
-    static var partiallyVaccinated: String { LanguageService.dynamicLocalizedString("View.Label.PartiallyMeetsRequirement") }
+    static var partiallyMeetsRequirement: String { LanguageService.dynamicLocalizedString("View.Label.PartiallyMeetsRequirement") }
     static var noRecordsFound: String { LanguageService.dynamicLocalizedString("View.Label.NoRecordsFound")
     }
     static var pleaseUpdate: String { LanguageService.dynamicLocalizedString("View.Label.PleaseUpdate")


### PR DESCRIPTION
The client will be expanding the QR codes issued by the Government of Yukon, and the existing status screen wording is too narrow. The client would like to update the language on the ‘Partially vaccinated’ screen to read 'Partially meets requirement’. This update is also required in the French version of the app.