### PR TITLE
chore: Update the 'BCVaccineValidator' pod, and app version

### DIFF
--- a/YukonVaccinationVerifier/Podfile
+++ b/YukonVaccinationVerifier/Podfile
@@ -14,7 +14,7 @@ target 'YukonVaccinationVerifier' do
 
   # Pods for YukonVaccinationVerifier
 
-  pod 'BCVaccineValidator', :git => 'https://github.com/AfsarFresh/iOSVaccineValidator.git', :tag => 'YVV_V_1_2_2_B_1'
+  pod 'BCVaccineValidator', :git => 'https://github.com/AfsarFresh/iOSVaccineValidator.git', :tag => '1_3_B_1-Testing'
 
   # pod 'BCVaccineValidator', :git => 'https://github.com/AfsarFresh/iOSVaccineValidator.git', :branch => 'timeBetweenDosesAndYukonExemptions'
   

--- a/YukonVaccinationVerifier/Podfile.lock
+++ b/YukonVaccinationVerifier/Podfile.lock
@@ -1,12 +1,12 @@
 PODS:
-  - Alamofire (5.5.0)
-  - BCVaccineValidator (1.0.9):
+  - Alamofire (5.4.4)
+  - BCVaccineValidator (1.0.12):
     - Alamofire
     - JOSESwift
   - JOSESwift (2.4.0)
 
 DEPENDENCIES:
-  - BCVaccineValidator (from `https://github.com/AfsarFresh/iOSVaccineValidator.git`, tag `YVV_V_1_2_2_B_1`)
+  - BCVaccineValidator (from `https://github.com/AfsarFresh/iOSVaccineValidator.git`, tag `1_3_B_1-Testing`)
 
 SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
@@ -16,18 +16,18 @@ SPEC REPOS:
 EXTERNAL SOURCES:
   BCVaccineValidator:
     :git: https://github.com/AfsarFresh/iOSVaccineValidator.git
-    :tag: YVV_V_1_2_2_B_1
+    :tag: 1_3_B_1-Testing
 
 CHECKOUT OPTIONS:
   BCVaccineValidator:
     :git: https://github.com/AfsarFresh/iOSVaccineValidator.git
-    :tag: YVV_V_1_2_2_B_1
+    :tag: 1_3_B_1-Testing
 
 SPEC CHECKSUMS:
-  Alamofire: 1c4fb5369c3fe93d2857c780d8bbe09f06f97e7c
-  BCVaccineValidator: 9f5ecb5accb833cbeab1220df42f7d5235be2eee
+  Alamofire: f3b09a368f1582ab751b3fff5460276e0d2cf5c9
+  BCVaccineValidator: 7a41c49aa40531f74d9fb5104a5b7b104527d6d4
   JOSESwift: 7ff178bb9173ff42c6e990929a9f2fa702a34f69
 
-PODFILE CHECKSUM: af30e8c31fdb50f97594eb7c0d53b754fbd3a688
+PODFILE CHECKSUM: 60f3ffdf294ba5c750a25bde1af74d3cbdad2772
 
 COCOAPODS: 1.11.2

--- a/YukonVaccinationVerifier/YukonVaccinationVerifier.xcodeproj/project.pbxproj
+++ b/YukonVaccinationVerifier/YukonVaccinationVerifier.xcodeproj/project.pbxproj
@@ -573,7 +573,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2;
+				MARKETING_VERSION = 1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = io.freshworks.YukonVaccinationVerifier;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "Yukon Vaccination Verifier - Ad Hoc";
@@ -659,7 +659,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2;
+				MARKETING_VERSION = 1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = io.freshworks.YukonVaccinationVerifier;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG DEV";
@@ -740,7 +740,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2;
+				MARKETING_VERSION = 1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.freshworks.YukonVaccinationVerifier-TST";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "Yukon Vaccination Verifier TST";
@@ -822,7 +822,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2;
+				MARKETING_VERSION = 1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "ca.yk.gov.vaxcheck-STG";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "Yukon Vaccine Verifier distribution - STG";
@@ -904,7 +904,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2;
+				MARKETING_VERSION = 1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = ca.yk.gov.vaxcheck;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "Yukon Vaccine Verifier distribution";

--- a/YukonVaccinationVerifier/YukonVaccinationVerifier/AppDelegate.swift
+++ b/YukonVaccinationVerifier/YukonVaccinationVerifier/AppDelegate.swift
@@ -34,8 +34,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         #elseif STG
             mode = .Prod
         #elseif TST
-//            mode = .Test
-            mode = .Dev
+            mode = .Test
         #elseif DEV
             mode = .Dev
         #else

--- a/YukonVaccinationVerifier/YukonVaccinationVerifier/AppDelegate.swift
+++ b/YukonVaccinationVerifier/YukonVaccinationVerifier/AppDelegate.swift
@@ -34,7 +34,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         #elseif STG
             mode = .Prod
         #elseif TST
-            mode = .Test
+//            mode = .Test
+            mode = .Dev
         #elseif DEV
             mode = .Dev
         #else


### PR DESCRIPTION
The government of Yukon, using the SMART Health Card issuer, will be able to begin issuing temporary PVC to visitors. These PVCs will expire on a certain date/time, as determined by the issuer (new keyname: exp). The Yukon Government would like the app to appropriately decode the new keyname, and indicate that it is an ‘Invalid QR’ once the PVC has expired.